### PR TITLE
Update package vendor name to match Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "dealer-inspire/laravel-performance-monitor",
+  "name": "dealerinspire/laravel-performance-monitor",
   "description": "A performance monitor to log an error when a request performs below a specified threshold",
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
The vendor name in Packagist is `dealerinspire`, and we've already used that as the vendor name for our `laravel-coding-standard` package which would be very painful to change at this point. Plus most other vendors with multiple words in their name just use a non-hyphenated version as it is easier to type, easier to remember, and in my opinion, it looks nicer.